### PR TITLE
Resolve build problems with Xcode 16

### DIFF
--- a/Sources/WireGuardKitC/WireGuardKitC.h
+++ b/Sources/WireGuardKitC/WireGuardKitC.h
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2021 WireGuard LLC. All Rights Reserved.
 
+#include <sys/types.h>
+
 #include "key.h"
 #include "x25519.h"
 

--- a/Sources/WireGuardKitC/WireGuardKitC.h
+++ b/Sources/WireGuardKitC/WireGuardKitC.h
@@ -4,37 +4,17 @@
 #include "key.h"
 #include "x25519.h"
 
-
-//
-// Note from CJ 2024-06-13
-// Xcode 16 beta 1 broke compatibility by removing the type definitions for u_int32_t
-// which are old lingering references to the BSD origins of xnu
-// https://opensource.apple.com/source/xnu/xnu-344/bsd/sys/kern_control.h.auto.html
-// There are two ways to resolve this
-//
-// this way
-//typedef unsigned int u_int32_t;
-//typedef unsigned char u_char;
-//typedef unsigned short u_int16_t;
-//
-// or
-// typedef uint32_t u_int32_t;
-//typedef uint8_t u_char;
-//typedef uint16_t u_int16_t;
-//
-// I opted for skipping right past all of the typedefs and using the solution below
-
 /* From <sys/kern_control.h> */
 #define CTLIOCGINFO 0xc0644e03UL
 struct ctl_info {
-	unsigned int   ctl_id;
+    u_int32_t   ctl_id;
     char        ctl_name[96];
 };
 struct sockaddr_ctl {
-    unsigned char      sc_len;
-    unsigned char      sc_family;
-    unsigned short   ss_sysaddr;
-    unsigned int   sc_id;
-	unsigned int   sc_unit;
-	unsigned int   sc_reserved[5];
+    u_char      sc_len;
+    u_char      sc_family;
+    u_int16_t   ss_sysaddr;
+    u_int32_t   sc_id;
+    u_int32_t   sc_unit;
+    u_int32_t   sc_reserved[5];
 };


### PR DESCRIPTION
I believe that the approach to resolving build problems with Xcode 16 from this pull request https://github.com/WireGuard/wireguard-apple/pull/33 into upstream `wireguard-apple` is better than the currently implemented fix in `grd-wireguard-apple`

I reverted the initial fix, and applied the fix from the aforementioned pull request

Can confirm that it works on Xcode 16.0 (stable version)